### PR TITLE
use fmt in header-only mode

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -9,6 +9,7 @@ LGB_CPPFLAGS = \
 
 PKG_CPPFLAGS = \
     -I$(PKGROOT)/include \
+    -DFMT_HEADER_ONLY \
     $(LGB_CPPFLAGS)
 
 PKG_CXXFLAGS = \
@@ -27,8 +28,6 @@ OBJECTS = \
     boosting/gbdt_model_text.o \
     boosting/gbdt_prediction.o \
     boosting/prediction_early_stop.o \
-    external_libs/fmt/format.o \
-    external_libs/fmt/os.o \
     io/bin.o \
     io/config.o \
     io/config_auto.o \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -9,6 +9,7 @@ LGB_CPPFLAGS = \
 
 PKG_CPPFLAGS = \
     -I$(PKGROOT)/include \
+    -DFMT_HEADER_ONLY \
     $(LGB_CPPFLAGS)
 
 PKG_CXXFLAGS = \
@@ -28,8 +29,6 @@ OBJECTS = \
     boosting/gbdt_model_text.o \
     boosting/gbdt_prediction.o \
     boosting/prediction_early_stop.o \
-    fmt/format.o \
-    fmt/os.o \
     io/bin.o \
     io/config.o \
     io/config_auto.o \

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -32,11 +32,6 @@ cp \
     external_libs/fast_double_parser/include/fast_double_parser.h \
     ${TEMP_R_DIR}/src/include/LightGBM
 
-mkdir -p ${TEMP_R_DIR}/src/external_libs/fmt
-cp \
-    external_libs/fmt/src/*.cc \
-    ${TEMP_R_DIR}/src/external_libs/fmt/
-
 mkdir -p ${TEMP_R_DIR}/src/include/LightGBM/fmt
 cp \
     external_libs/fmt/include/fmt/*.h \
@@ -77,16 +72,6 @@ cd ${TEMP_R_DIR}
         "${file}"
     done
     rm src/include/LightGBM/*.h.bak
-
-    sed \
-        -i.bak \
-        -e 's/fmt\/format-inl\.h/LightGBM\/fmt\/format-inl\.h/' \
-        src/external_libs/fmt/format.cc
-
-    sed \
-        -i.bak \
-        -e 's/fmt\/os\.h/LightGBM\/fmt\/os\.h/' \
-        src/external_libs/fmt/os.cc
 
     sed \
         -i.bak \


### PR DESCRIPTION
Trying to use `fmt` in header-only mode in the CRAN version of the R package, in response to https://github.com/microsoft/LightGBM/pull/3405#issuecomment-719920795